### PR TITLE
🚚 move to `ddev` domain

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ defaults:
     shell: bash
 
 env:
-  NIGHTLY_DDEV_PR_URL: "https://nightly.link/drud/ddev/actions/runs/1720215802/ddev-linux-amd64.zip"
+  NIGHTLY_DDEV_PR_URL: "https://nightly.link/ddev/ddev/actions/runs/1720215802/ddev-linux-amd64.zip"
 
 jobs:
   tests:
@@ -45,15 +45,15 @@ jobs:
 
     - name: Use ddev stable
       if: matrix.ddev_version == 'stable'
-      run: brew install drud/ddev/ddev
+      run: brew install ddev/ddev/ddev
 
     - name: Use ddev edge
       if: matrix.ddev_version == 'edge'
-      run: brew install drud/ddev-edge/ddev
+      run: brew install ddev/ddev-edge/ddev
 
     - name: Use ddev HEAD
       if: matrix.ddev_version == 'HEAD'
-      run: brew install --HEAD drud/ddev/ddev
+      run: brew install --HEAD ddev/ddev/ddev
 
     - name: Use ddev PR
       if: matrix.ddev_version == 'PR'
@@ -63,7 +63,7 @@ jobs:
         mv ddev /usr/local/bin/ddev && chmod +x /usr/local/bin/ddev
 
     - name: Download docker images
-      run: | 
+      run: |
         mkdir junk && pushd junk && ddev config --auto && ddev debug download-images >/dev/null
         docker pull redis:6 >/dev/null
     - name: tmate debugging session

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-[![tests](https://github.com/drud/ddev-redis/actions/workflows/tests.yml/badge.svg)](https://github.com/drud/ddev-redis/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
+[![tests](https://github.com/ddev/ddev-redis/actions/workflows/tests.yml/badge.svg)](https://github.com/ddev/ddev-redis/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
 
 ## What is this?
 
-This repository allows you to quickly install redis into a [Ddev](https://ddev.readthedocs.io) project using just `ddev get drud/ddev-redis`.
+This repository allows you to quickly install redis into a [Ddev](https://ddev.readthedocs.io) project using just `ddev get ddev/ddev-redis`.
 
 ## Installation
 
-1. `ddev get drud/ddev-redis`
+1. `ddev get ddev/ddev-redis`
 2. `ddev restart`
 
 ## Explanation
@@ -19,4 +19,4 @@ This redis recipe for [ddev](https://ddev.readthedocs.io) installs a [`.ddev/doc
 * Configure your application to access redis on the host:port `redis:6379`.
 * To reach the redis CLI interface, run `ddev redis-cli` to begin a session. You can also run Redis CLI commands directly on the command-line, e.g., `ddev redis-cli INFO`.
 
-**Contributed and maintained by [@hussainweb](https://github.com/hussainweb) based on the original [ddev-contrib recipe](https://github.com/drud/ddev-contrib/tree/master/docker-compose-services/redis) by [@gormus](https://github.com/gormus)**
+**Contributed and maintained by [@hussainweb](https://github.com/hussainweb) based on the original [ddev-contrib recipe](https://github.com/ddev/ddev-contrib/tree/master/docker-compose-services/redis) by [@gormus](https://github.com/gormus)**


### PR DESCRIPTION
This PR updates documents and tests for the move to `ddev` domain.