### PR TITLE
Remove obsolete docker-compose version: 3.6

### DIFF
--- a/docker-compose.redis.yaml
+++ b/docker-compose.redis.yaml
@@ -1,5 +1,4 @@
 #ddev-generated
-version: '3.6'
 services:
   redis:
     container_name: ddev-${DDEV_SITENAME}-redis


### PR DESCRIPTION
Remove obsolete docker-compose version: 3.6