### PR TITLE
Use redis:6-bullseye to support old systems, update GitHub test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,8 +28,8 @@ env:
   DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # Allow `--HEAD` flag when running tests against HEAD
   HOMEBREW_NO_INSTALL_FROM_API: 1
-  # Pull the same tag as in docker-compose.redis.yaml
-  REDIS_IMAGE_TAG: 6-bullseye
+  # Pull the same image as in docker-compose.redis.yaml
+  REDIS_IMAGE: redis:6-bullseye
 jobs:
   tests:
     defaults:
@@ -76,7 +76,7 @@ jobs:
     - name: Download docker images
       run: |
         mkdir junk && pushd junk && ddev config --auto && ddev debug download-images >/dev/null
-        docker pull redis:${REDIS_IMAGE_TAG} >/dev/null
+        docker pull ${REDIS_IMAGE} >/dev/null
     - name: tmate debugging session
       uses: mxschmitt/action-tmate@v3
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ permissions:
 
 env:
   NIGHTLY_DDEV_PR_URL: "https://nightly.link/ddev/ddev/actions/runs/1720215802/ddev-linux-amd64.zip"
-  # Allow ddev get to use a github token to prevent rate limiting by tests
+  # Allow ddev get to use a GitHub token to prevent rate limiting by tests
   DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # Allow `--HEAD` flag when running tests against HEAD
   HOMEBREW_NO_INSTALL_FROM_API: 1
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Homebrew
       id: set-up-homebrew
       uses: Homebrew/actions/setup-homebrew@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,8 @@ env:
   DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # Allow `--HEAD` flag when running tests against HEAD
   HOMEBREW_NO_INSTALL_FROM_API: 1
+  # Pull the same tag as in docker-compose.redis.yaml
+  REDIS_IMAGE_TAG: 6-bullseye
 jobs:
   tests:
     defaults:
@@ -74,7 +76,7 @@ jobs:
     - name: Download docker images
       run: |
         mkdir junk && pushd junk && ddev config --auto && ddev debug download-images >/dev/null
-        docker pull redis:6 >/dev/null
+        docker pull redis:${REDIS_IMAGE_TAG} >/dev/null
     - name: tmate debugging session
       uses: mxschmitt/action-tmate@v3
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,8 +26,6 @@ env:
   NIGHTLY_DDEV_PR_URL: "https://nightly.link/ddev/ddev/actions/runs/1720215802/ddev-linux-amd64.zip"
   # Allow ddev get to use a GitHub token to prevent rate limiting by tests
   DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  # Allow `--HEAD` flag when running tests against HEAD
-  HOMEBREW_NO_INSTALL_FROM_API: 1
   # Pull the same image as in docker-compose.redis.yaml
   REDIS_IMAGE: redis:6-bullseye
 jobs:
@@ -42,7 +40,7 @@ jobs:
 #        ddev_version: [PR]
       fail-fast: false
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3

--- a/docker-compose.redis.yaml
+++ b/docker-compose.redis.yaml
@@ -2,7 +2,7 @@
 services:
   redis:
     container_name: ddev-${DDEV_SITENAME}-redis
-    image: redis:6
+    image: redis:6-bullseye
     # These labels ensure this service is discoverable by ddev.
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}


### PR DESCRIPTION
## The Issue

Per support ticket in https://discord.com/channels/664580571770388500/1134183410773008554 this addon fails to start with Docker 20.10.7 (released on 2021-06-02) on Ubuntu 20.04.

The actual error is:

```
1:M 26 Jul 2023 23:50:34.371 # Fatal: Can't initialize Background Jobs.
```

<details><summary>Full `ddev logs -s redis`</summary>
  
```
1:C 26 Jul 2023 23:50:34.369 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
1:C 26 Jul 2023 23:50:34.369 # Redis version=6.2.13, bits=64, commit=00000000, modified=0, pid=1, just started
1:C 26 Jul 2023 23:50:34.369 # Configuration loaded
1:M 26 Jul 2023 23:50:34.370 * monotonic clock: POSIX clock_gettime
1:M 26 Jul 2023 23:50:34.371 * Running mode=standalone, port=6379.
1:M 26 Jul 2023 23:50:34.371 # Server initialized
1:M 26 Jul 2023 23:50:34.371 # WARNING Memory overcommit must be enabled! Without it, a background save or replication may fail under low memory condition. Being disabled, it can can also cause failures without low memory condition, see https://github.com/jemalloc/jemalloc/issues/1328. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
1:M 26 Jul 2023 23:50:34.371 # Fatal: Can't initialize Background Jobs.
```

</details>

This issue is caused by the migration from Debian `bullseye` to `bookworm` base for the `redis` image.

## How This PR Solves The Issue

This PR replaces `redis:6` with `redis:6-bullseye`. We can support a wider range of systems that pull this add-on using the `redis:*-bullseye` tag.

This is NOT a long term solution, as the `bullseye` tags may not have updates in the future.

## Manual Testing Instructions

## Automated Testing Overview

GitHub actions use the updated images, so this issue was not detected here.

## Related Issue Link(s)

- https://github.com/docker-library/redis/issues/365
