### PR TITLE
Remove anonymous Redis volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This repository allows you to quickly install Redis into a [DDEV](https://ddev.r
 
 This Redis recipe for [DDEV](https://ddev.readthedocs.io) installs a [`.ddev/docker-compose.redis.yaml`](docker-compose.redis.yaml) using the `redis` Docker image.
 
+Persistence is disabled by default (see [redis.conf](./redis/redis.conf)), follow the config instructions to enable it, or switch to https://github.com/ddev/ddev-redis-7 where it is enabled by default.
+
 ## Interacting with Redis
 
 * The Redis instance will listen on TCP port 6379 (the Redis default).

--- a/commands/redis/redis-cli
+++ b/commands/redis/redis-cli
@@ -2,6 +2,6 @@
 #ddev-generated
 ## Description: Run redis-cli inside the redis container
 ## Usage: redis-cli [flags] [args]
-## Example: "redis-cli KEYS *" or "ddev redis-cli INFO" or "ddev redis-cli --version"
+## Example: "ddev redis-cli KEYS *" or "ddev redis-cli INFO" or "ddev redis-cli --version"
 
 redis-cli -p 6379 -h redis $@

--- a/docker-compose.redis.yaml
+++ b/docker-compose.redis.yaml
@@ -10,4 +10,8 @@ services:
     volumes:
     - ".:/mnt/ddev_config"
     - "./redis:/usr/local/etc/redis"
+    - "redis:/data"
     command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
+
+volumes:
+  redis:

--- a/redis/redis.conf
+++ b/redis/redis.conf
@@ -6,3 +6,9 @@
 
 maxmemory 2048mb
 maxmemory-policy allkeys-lfu
+
+# If you want to enable Redis persistence,
+# remove ddev-generated from this file,
+# and comment the two lines below:
+appendonly no
+save ""


### PR DESCRIPTION
## The Issue

- #18

We need to get rid of anonymous Redis `/data` volume.

## How This PR Solves The Issue

Adds a named volume for Redis.

This change is not breaking, Redis will work as before, but won't create anonymous volumes on every `ddev restart`.

I could enable persistence by default, but I've never needed it, I've always used Redis as a cache.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

