### PR TITLE
services should mount ddev-global-cache

### DIFF
--- a/docker-compose.redis.yaml
+++ b/docker-compose.redis.yaml
@@ -9,6 +9,7 @@ services:
       com.ddev.approot: $DDEV_APPROOT
     volumes:
     - ".:/mnt/ddev_config"
+    - "ddev-global-cache:/mnt/ddev-global-cache"
     - "./redis:/usr/local/etc/redis"
     - "redis:/data"
     command: ["redis-server", "/usr/local/etc/redis/redis.conf"]


### PR DESCRIPTION
## The Issue

All services should mount ddev-global-cache, see https://ddev.readthedocs.io/en/latest/users/extend/custom-compose-files/#third-party-services-may-need-to-trust-ddev-webserver

We may need better docs about this.

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

