### PR TITLE
Add optional `--redis-tag` flag, fixes #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ This repository allows you to quickly install Redis into a [DDEV](https://ddev.r
 1. `ddev get ddev/ddev-redis`
 2. `ddev restart`
 
+Using DDEV v1.23.4+, you can select a different Redis version with:
+
+1. `ddev get ddev/ddev-redis --environment="REDIS_VERSION=7"`
+2. `ddev restart`
+
 ## Explanation
 
 This Redis recipe for [DDEV](https://ddev.readthedocs.io) installs a [`.ddev/docker-compose.redis.yaml`](docker-compose.redis.yaml) using the `redis` Docker image.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository allows you to quickly install Redis into a [DDEV](https://ddev.r
 
 With DDEV v1.23.5+ you can choose a different Redis tag, the command below creates a `.ddev/.env.redis` file that you can commit:
 
-1. `ddev add-on get ddev/ddev-redis --redis-tag 7`
+1. `ddev dotenv set .ddev/.env.redis --redis-tag 7`
 2. `ddev restart`
 
 ## Explanation

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ This repository allows you to quickly install Redis into a [DDEV](https://ddev.r
 1. `ddev get ddev/ddev-redis`
 2. `ddev restart`
 
-Using DDEV v1.23.5+, you can select a different Redis version with:
+With DDEV v1.23.5+ you can choose a different Redis tag, the command below creates a `.ddev/.env.redis` file that you can commit:
 
-1. `ddev get ddev/ddev-redis --environment="DDEV_REDIS_VERSION=7"`
+1. `ddev add-on get ddev/ddev-redis --redis-tag 7`
 2. `ddev restart`
 
 ## Explanation

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository allows you to quickly install Redis into a [DDEV](https://ddev.r
 
 Using DDEV v1.23.4+, you can select a different Redis version with:
 
-1. `ddev get ddev/ddev-redis --environment="REDIS_VERSION=7"`
+1. `ddev get ddev/ddev-redis --environment="DDEV_REDIS_VERSION=7"`
 2. `ddev restart`
 
 ## Explanation

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository allows you to quickly install Redis into a [DDEV](https://ddev.r
 1. `ddev get ddev/ddev-redis`
 2. `ddev restart`
 
-Using DDEV v1.23.4+, you can select a different Redis version with:
+Using DDEV v1.23.5+, you can select a different Redis version with:
 
 1. `ddev get ddev/ddev-redis --environment="DDEV_REDIS_VERSION=7"`
 2. `ddev restart`

--- a/docker-compose.redis.yaml
+++ b/docker-compose.redis.yaml
@@ -2,7 +2,7 @@
 services:
   redis:
     container_name: ddev-${DDEV_SITENAME}-redis
-    image: redis:${REDIS_VERSION:-6-bullseye}
+    image: redis:${DDEV_REDIS_VERSION:-6-bullseye}
     # These labels ensure this service is discoverable by ddev.
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}

--- a/docker-compose.redis.yaml
+++ b/docker-compose.redis.yaml
@@ -2,7 +2,7 @@
 services:
   redis:
     container_name: ddev-${DDEV_SITENAME}-redis
-    image: redis:${DDEV_REDIS_VERSION:-6-bullseye}
+    image: redis:${REDIS_TAG:-6-bullseye}
     # These labels ensure this service is discoverable by ddev.
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}

--- a/docker-compose.redis.yaml
+++ b/docker-compose.redis.yaml
@@ -2,7 +2,7 @@
 services:
   redis:
     container_name: ddev-${DDEV_SITENAME}-redis
-    image: redis:6-bullseye
+    image: redis:${REDIS_VERSION:-6-bullseye}
     # These labels ensure this service is discoverable by ddev.
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -14,10 +14,10 @@ teardown() {
 }
 
 @test "basic installation" {
-  ddev config --project-name=${PROJNAME} --project-type=drupal9 --docroot=web --create-docroot
+  ddev config --project-name=${PROJNAME} --project-type=drupal --docroot=web
   ddev start -y
   cd ${TESTDIR}
-  ddev get ${DIR}
+  ddev add-on get ${DIR}
   ddev restart
   ddev redis-cli INFO | grep "^redis_version:6."
   # Check if Redis configuration was setup.
@@ -25,11 +25,25 @@ teardown() {
   grep -F 'settings.ddev.redis.php' web/sites/default/settings.php
 }
 
-@test "non-Drupal installation" {
-  ddev config --project-name=${PROJNAME} --project-type=laravel --docroot=web --create-docroot
+@test "basic installation with Redis tag 7" {
+  ddev config --project-name=${PROJNAME} --project-type=drupal --docroot=web
   ddev start -y
   cd ${TESTDIR}
-  ddev get ${DIR}
+  ddev add-on get ${DIR} --redis-tag=7
+  # Check if .env file for Redis exists.
+  [ -f .ddev/.env.redis ]
+  ddev restart
+  ddev redis-cli INFO | grep "^redis_version:7."
+  # Check if Redis configuration was setup.
+  [ -f web/sites/default/settings.ddev.redis.php ]
+  grep -F 'settings.ddev.redis.php' web/sites/default/settings.php
+}
+
+@test "non-Drupal installation" {
+  ddev config --project-name=${PROJNAME} --project-type=laravel --docroot=web
+  ddev start -y
+  cd ${TESTDIR}
+  ddev add-on get ${DIR}
   ddev restart
   ddev redis-cli INFO | grep "^redis_version:6."
   # Drupal configuration should not be present
@@ -37,10 +51,10 @@ teardown() {
 }
 
 @test "Drupal 7 installation" {
-  ddev config --project-name=${PROJNAME} --project-type=drupal7 --docroot=web --create-docroot
+  ddev config --project-name=${PROJNAME} --project-type=drupal7 --docroot=web
   ddev start -y
   cd ${TESTDIR}
-  ddev get ${DIR}
+  ddev add-on get ${DIR}
   ddev restart
   ddev redis-cli INFO | grep "^redis_version:6."
   # Drupal configuration should not be present
@@ -48,10 +62,10 @@ teardown() {
 }
 
 @test "Drupal 9 installation without settings management" {
-  ddev config --project-name=${PROJNAME} --disable-settings-management --project-type=drupal9 --docroot=web --create-docroot
+  ddev config --project-name=${PROJNAME} --disable-settings-management --project-type=drupal --docroot=web
   ddev start -y
   cd ${TESTDIR}
-  ddev get ${DIR}
+  ddev add-on get ${DIR}
   ddev restart
   ddev redis-cli INFO | grep "^redis_version:6."
   # Drupal configuration should not be present

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -29,7 +29,8 @@ teardown() {
   ddev config --project-name=${PROJNAME} --project-type=drupal --docroot=web
   ddev start -y
   cd ${TESTDIR}
-  ddev add-on get ${DIR} --redis-tag=7
+  ddev add-on get ${DIR}
+  ddev dotenv set .ddev/.env.redis --redis-tag=7
   # Check if .env file for Redis exists.
   [ -f .ddev/.env.redis ]
   ddev restart


### PR DESCRIPTION
## The Issue

- #1
- https://github.com/ddev/ddev/issues/4430

## How This PR Solves The Issue

Adds optional `--redis-tag value` flag, that creates `.ddev/.env.redis` file with `REDIS_TAG="value"`.

## Manual Testing Instructions

Install add-on using DDEV binary from:

- https://github.com/ddev/ddev/pull/6406

```
ddev add-on get https://github.com/ddev/ddev-redis/tarball/20240717_stasadev_optional_version
ddev dotenv set .ddev/.env.redis --redis-tag=7
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

