### PR TITLE
Remove Drupal related add-on files from `.ddev` when not applicable

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -17,7 +17,14 @@ post_install_actions:
 - |
   #ddev-nodisplay
   #ddev-description:Install redis settings for Drupal 9+ if applicable
-  redis/scripts/setup-drupal-settings.sh
+  if ! redis/scripts/setup-drupal-settings.sh; then
+    for file in redis/scripts/settings.ddev.redis.php redis/scripts/setup-drupal-settings.sh; do
+      if grep -q "#ddev-generated" "${file}" 2>/dev/null; then
+        echo "Removing ${file} as not applicable"
+        rm -f "${file}"
+      fi
+    done
+  fi
 
 removal_actions:
 - |

--- a/install.yaml
+++ b/install.yaml
@@ -17,14 +17,7 @@ post_install_actions:
 - |
   #ddev-nodisplay
   #ddev-description:Install redis settings for Drupal 9+ if applicable
-  if ! redis/scripts/setup-drupal-settings.sh; then
-    for file in redis/scripts/settings.ddev.redis.php redis/scripts/setup-drupal-settings.sh; do
-      if grep -q "#ddev-generated" "${file}" 2>/dev/null; then
-        echo "Removing ${file} as not applicable"
-        rm -f "${file}"
-      fi
-    done
-  fi
+  redis/scripts/setup-drupal-settings.sh
 
 removal_actions:
 - |

--- a/redis/scripts/setup-drupal-settings.sh
+++ b/redis/scripts/setup-drupal-settings.sh
@@ -4,11 +4,11 @@ set -e
 
 if [[ $DDEV_PROJECT_TYPE != drupal* ]] || [[ $DDEV_PROJECT_TYPE =~ ^drupal(6|7)$ ]] ;
 then
-  exit 0
+  exit 1
 fi
 
 if ( ddev debug configyaml 2>/dev/null | grep 'disable_settings_management:\s*true' >/dev/null 2>&1 ) ; then
-  exit 0
+  exit 2
 fi
 
 cp redis/scripts/settings.ddev.redis.php $DDEV_APPROOT/$DDEV_DOCROOT/sites/default/

--- a/redis/scripts/setup-drupal-settings.sh
+++ b/redis/scripts/setup-drupal-settings.sh
@@ -4,11 +4,17 @@ set -e
 
 if [[ $DDEV_PROJECT_TYPE != drupal* ]] || [[ $DDEV_PROJECT_TYPE =~ ^drupal(6|7)$ ]] ;
 then
-  exit 1
+  for file in redis/scripts/settings.ddev.redis.php redis/scripts/setup-drupal-settings.sh; do
+    if grep -q "#ddev-generated" "${file}" 2>/dev/null; then
+      echo "Removing ${file} as not applicable"
+      rm -f "${file}"
+    fi
+  done
+  exit 0
 fi
 
 if ( ddev debug configyaml 2>/dev/null | grep 'disable_settings_management:\s*true' >/dev/null 2>&1 ) ; then
-  exit 2
+  exit 0
 fi
 
 cp redis/scripts/settings.ddev.redis.php $DDEV_APPROOT/$DDEV_DOCROOT/sites/default/


### PR DESCRIPTION
## The Issue

When people install this add-on, some Drupal related files are installed to `.ddev` folder, even when the project is not Drupal.

## How This PR Solves The Issue

Removes these files in `post_install_action`.

## Manual Testing Instructions

Files are removed for non Drupal:
```
ddev config --project-type php
ddev add-on get https://github.com/ddev/ddev-redis/tarball/20241028_stasadev_drupal_files
...
Executing post-install actions:
Removing redis/scripts/settings.ddev.redis.php as not applicable
Removing redis/scripts/setup-drupal-settings.sh as not applicable
...
```
Files are NOT removed for Drupal:
```
ddev config --project-type drupal
ddev add-on get https://github.com/ddev/ddev-redis/tarball/20241028_stasadev_drupal_files
...
Executing post-install actions: 
Settings file name: /home/stas/code/ddev/d11/web/sites/default/settings.php
...
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

