### PR TITLE
feat: enable Redis persistence

### DIFF
--- a/redis/redis.conf
+++ b/redis/redis.conf
@@ -7,8 +7,7 @@
 maxmemory 2048mb
 maxmemory-policy allkeys-lfu
 
-# If you want to enable Redis persistence,
-# remove ddev-generated from this file,
-# and comment the two lines below:
-appendonly no
-save ""
+# to disable Redis persistence, remove ddev-generated from this file,
+# and uncomment the two lines below:
+#appendonly no
+#save ""


### PR DESCRIPTION
## The Issue

`ddev/ddev-redis-7` has it enabled by default.

## How This PR Solves The Issue

Let's enable it to align two repos.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-redis/tarball/20250425_stasadev_redis_persistence
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
