### PR TITLE
feat: add v1.24.3 version constraint

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -1,26 +1,20 @@
 name: redis
 
-pre_install_actions:
-
-# list of files and directories listed that are copied into project .ddev directory
 project_files:
-- docker-compose.redis.yaml
-- redis/scripts/settings.ddev.redis.php
-- redis/scripts/setup-drupal-settings.sh
-- redis/redis.conf
-- commands/redis/redis-cli
+  - docker-compose.redis.yaml
+  - redis/scripts/settings.ddev.redis.php
+  - redis/scripts/setup-drupal-settings.sh
+  - redis/redis.conf
+  - commands/redis/redis-cli
 
-# List of files and directories that are copied into the global .ddev directory
-global_files:
+ddev_version_constraint: '>= v1.24.3'
 
 post_install_actions:
-- |
-  #ddev-nodisplay
-  #ddev-description:Install redis settings for Drupal 9+ if applicable
-  redis/scripts/setup-drupal-settings.sh
+  - |
+    #ddev-description:Install redis settings for Drupal 9+ if applicable
+    redis/scripts/setup-drupal-settings.sh
 
 removal_actions:
-- |
-  #ddev-nodisplay
-  #ddev-description:Remove redis settings for Drupal 9+ if applicable
-  rm -f "${DDEV_APPROOT}/${DDEV_DOCROOT}/sites/default/settings.ddev.redis.php"
+  - |
+    #ddev-description:Remove redis settings for Drupal 9+ if applicable
+    rm -f "${DDEV_APPROOT}/${DDEV_DOCROOT}/sites/default/settings.ddev.redis.php"


### PR DESCRIPTION
## The Issue

Version constraint is set in upstream `ddev-addon-template`.

## How This PR Solves The Issue

Adds v1.24.3 version constraint.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-redis/tarball/20250425_stasadev_version_constraint
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
