### PR TITLE
feat: add `ddev redis` alias, add `ddev redis-flush`, set empty password

### DIFF
--- a/commands/redis/redis-cli
+++ b/commands/redis/redis-cli
@@ -1,7 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 #ddev-generated
-## Description: Run redis-cli inside the redis container
+## Description: Run redis-cli inside the Redis container
 ## Usage: redis-cli [flags] [args]
 ## Example: "ddev redis-cli KEYS *" or "ddev redis-cli INFO" or "ddev redis-cli --version"
+## Aliases: redis
 
-redis-cli -p 6379 -h redis $@
+redis-cli -p 6379 -h redis -a "" --no-auth-warning "$@"
+

--- a/commands/redis/redis-flush
+++ b/commands/redis/redis-flush
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Description: Flush all cache inside the Redis container
+## Usage: redis-flush
+## Example: "ddev redis-flush"
+
+redis-cli -a "" --no-auth-warning FLUSHALL ASYNC

--- a/redis/redis.conf
+++ b/redis/redis.conf
@@ -11,3 +11,8 @@ maxmemory-policy allkeys-lfu
 # and uncomment the two lines below:
 #appendonly no
 #save ""
+
+# user config ending with "on >" means empty password
+# user config ending with "on >redis" means "redis" password
+user default ~* &* +@all on >
+user redis ~* &* +@all on >


### PR DESCRIPTION
## The Issue

`ddev/ddev-redis-7` has command `ddev redis`, we can add an alias for this.

Also, there is a `ddev redis-flush` command in `ddev/ddev-redis-7`.

## How This PR Solves The Issue

- Adds the mentioned commands.
- Explicitly sets an empty password (by default it is empty).

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-redis/tarball/20250425_stasadev_commands
ddev restart
ddev redis INFO
ddev redis-cli INFO
ddev redis-flush
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
