### PR TITLE
feat: use `redis:7` instead of `redis:6-bullseye`, move Redis config, for #17

### DIFF
--- a/docker-compose.redis.yaml
+++ b/docker-compose.redis.yaml
@@ -2,17 +2,20 @@
 services:
   redis:
     container_name: ddev-${DDEV_SITENAME}-redis
-    image: redis:${REDIS_TAG:-6-bullseye}
+    image: redis:${REDIS_TAG:-7}
     # These labels ensure this service is discoverable by ddev.
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: $DDEV_APPROOT
+      com.ddev.approot: ${DDEV_APPROOT}
+    restart: "no"
+    expose:
+      - 6379
     volumes:
-    - ".:/mnt/ddev_config"
-    - "ddev-global-cache:/mnt/ddev-global-cache"
-    - "./redis:/usr/local/etc/redis"
-    - "redis:/data"
-    command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
+      - ".:/mnt/ddev_config"
+      - "ddev-global-cache:/mnt/ddev-global-cache"
+      - "./redis:/etc/redis/conf"
+      - "redis:/data"
+    command: /etc/redis/conf/redis.conf
 
 volumes:
   redis:

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -19,22 +19,22 @@ teardown() {
   cd ${TESTDIR}
   ddev add-on get ${DIR}
   ddev restart
-  ddev redis-cli INFO | grep "^redis_version:6."
+  ddev redis-cli INFO | grep "^redis_version:7."
   # Check if Redis configuration was setup.
   [ -f web/sites/default/settings.ddev.redis.php ]
   grep -F 'settings.ddev.redis.php' web/sites/default/settings.php
 }
 
-@test "basic installation with Redis tag 7" {
+@test "basic installation with Redis tag 6" {
   ddev config --project-name=${PROJNAME} --project-type=drupal --docroot=web
   ddev start -y
   cd ${TESTDIR}
   ddev add-on get ${DIR}
-  ddev dotenv set .ddev/.env.redis --redis-tag=7
+  ddev dotenv set .ddev/.env.redis --redis-tag=6
   # Check if .env file for Redis exists.
   [ -f .ddev/.env.redis ]
   ddev restart
-  ddev redis-cli INFO | grep "^redis_version:7."
+  ddev redis-cli INFO | grep "^redis_version:6."
   # Check if Redis configuration was setup.
   [ -f web/sites/default/settings.ddev.redis.php ]
   grep -F 'settings.ddev.redis.php' web/sites/default/settings.php
@@ -46,7 +46,7 @@ teardown() {
   cd ${TESTDIR}
   ddev add-on get ${DIR}
   ddev restart
-  ddev redis-cli INFO | grep "^redis_version:6."
+  ddev redis-cli INFO | grep "^redis_version:7."
   # Drupal configuration should not be present
   [ ! -f web/sites/default/settings.ddev.redis.php ]
 }
@@ -57,7 +57,7 @@ teardown() {
   cd ${TESTDIR}
   ddev add-on get ${DIR}
   ddev restart
-  ddev redis-cli INFO | grep "^redis_version:6."
+  ddev redis-cli INFO | grep "^redis_version:7."
   # Drupal configuration should not be present
   [ ! -f web/sites/default/settings.ddev.redis.php ]
 }
@@ -68,7 +68,7 @@ teardown() {
   cd ${TESTDIR}
   ddev add-on get ${DIR}
   ddev restart
-  ddev redis-cli INFO | grep "^redis_version:6."
+  ddev redis-cli INFO | grep "^redis_version:7."
   # Drupal configuration should not be present
   [ ! -f web/sites/default/settings.ddev.redis.php ]
 }


### PR DESCRIPTION
## The Issue

We used old `redis:6-bullseye` only to support older systems.

- #17

This change was done almost 2 years ago, it's time to update.

## How This PR Solves The Issue

- Uses `redis:7` by default.
- Moves Redis config to the same location as in `ddev/ddev-redis-7`
- People still can use `redis:6-bullseye` if they set it explicitly.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-redis/tarball/20250425_stasadev_redis_7
ddev restart

# check for redis 7
ddev redis-cli INFO
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
