### PR TITLE
feat: replace `--redis-tag` with `--redis-docker-image`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ ddev restart
 
 With DDEV v1.23.5+ you can choose a different Redis tag, the command below creates a `.ddev/.env.redis` file that you can commit:
 
-1. `ddev dotenv set .ddev/.env.redis --redis-tag 7`
+1. `ddev dotenv set .ddev/.env.redis --redis-docker-image=redis:6`
 2. `ddev restart`
 
 ## Explanation

--- a/docker-compose.redis.yaml
+++ b/docker-compose.redis.yaml
@@ -2,7 +2,7 @@
 services:
   redis:
     container_name: ddev-${DDEV_SITENAME}-redis
-    image: redis:${REDIS_TAG:-7}
+    image: ${REDIS_DOCKER_IMAGE:-redis:7}
     # These labels ensure this service is discoverable by ddev.
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -30,7 +30,7 @@ teardown() {
   ddev start -y
   cd ${TESTDIR}
   ddev add-on get ${DIR}
-  ddev dotenv set .ddev/.env.redis --redis-tag=6
+  ddev dotenv set .ddev/.env.redis --redis-docker-image=redis:6
   # Check if .env file for Redis exists.
   [ -f .ddev/.env.redis ]
   ddev restart


### PR DESCRIPTION
## The Issue

`--redis-tag` (`REDIS_TAG`) is not flexible enough, people may want to use something else instead of `redis`.

## How This PR Solves The Issue

Adds `--redis-docker-image` flag for `REDIS_DOCKER_IMAGE`.

## Manual Testing Instructions

```bash
ddev dotenv set .ddev/.env.redis --redis-docker-image=redis:6
ddev add-on get https://github.com/ddev/ddev-redis/tarball/20250425_stasadev_replace_redis_tag_flag
ddev restart

# should show 6
ddev redis INFO
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
