### PR TITLE
test: update bats, add more checks in tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,26 +5,22 @@ on:
     branches: [ main ]
 
   schedule:
-  - cron: '01 07 * * *'
+  - cron: '25 08 * * *'
 
   workflow_dispatch:
     inputs:
       debug_enabled:
-        description: 'Debug with tmate set "debug_enabled"'
+        type: boolean
+        description: Debug with tmate
         required: false
-        default: "false"
+        default: false
 
-defaults:
-  run:
-    shell: bash
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
-env:
-  # Allow ddev get to use a github token to prevent rate limiting by tests
-  DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-# Required permissions for keep-alive, used by ddev/github-action-add-on-test
 permissions:
-  actions: write
+  contents: read
 
 jobs:
   tests:
@@ -36,10 +32,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: ddev/github-action-add-on-test@v2
-      with:
-        ddev_version: ${{ matrix.ddev_version }}
-        token: ${{ secrets.GITHUB_TOKEN }}
-        debug_enabled: ${{ github.event.inputs.debug_enabled }}
-        addon_repository: ${{ env.GITHUB_REPOSITORY }}
-        addon_ref: ${{ env.GITHUB_REF }}
+      - uses: ddev/github-action-add-on-test@v2
+        with:
+          ddev_version: ${{ matrix.ddev_version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          debug_enabled: ${{ github.event.inputs.debug_enabled }}
+          addon_repository: ${{ env.GITHUB_REPOSITORY }}
+          addon_ref: ${{ env.GITHUB_REF }}

--- a/install.yaml
+++ b/install.yaml
@@ -6,6 +6,7 @@ project_files:
   - redis/scripts/setup-drupal-settings.sh
   - redis/redis.conf
   - commands/redis/redis-cli
+  - commands/redis/redis-flush
 
 ddev_version_constraint: '>= v1.24.3'
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,74 +1,216 @@
+#!/usr/bin/env bats
+
+# Bats is a testing framework for Bash
+# Documentation https://bats-core.readthedocs.io/en/stable/
+# Bats libraries documentation https://github.com/ztombol/bats-docs
+
+# For local tests, install bats-core, bats-assert, bats-file, bats-support
+# And run this in the add-on root directory:
+#   bats ./tests/test.bats
+# To exclude release tests:
+#   bats ./tests/test.bats --filter-tags '!release'
+# For debugging:
+#   bats ./tests/test.bats --show-output-of-passing-tests --verbose-run --print-output-on-failure
+
 setup() {
-  export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
-  export TESTDIR=$(mktemp -d -t testredis-XXXXXXXXXX)
-  export PROJNAME=testredis
-  export DDEV_NON_INTERACTIVE=true
-  ddev delete -Oy ${PROJNAME} || true
+  set -eu -o pipefail
+
+  # Override this variable for your add-on:
+  export GITHUB_REPO=ddev/ddev-redis
+
+  TEST_BREW_PREFIX="$(brew --prefix 2>/dev/null || true)"
+  export BATS_LIB_PATH="${BATS_LIB_PATH}:${TEST_BREW_PREFIX}/lib:/usr/lib/bats"
+  bats_load_library bats-assert
+  bats_load_library bats-file
+  bats_load_library bats-support
+
+  export DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." >/dev/null 2>&1 && pwd)"
+  export PROJNAME="test-$(basename "${GITHUB_REPO}")"
+  mkdir -p ~/tmp
+  export TESTDIR=$(mktemp -d ~/tmp/${PROJNAME}.XXXXXX)
+  export DDEV_NONINTERACTIVE=true
+  export DDEV_NO_INSTRUMENTATION=true
+  ddev delete -Oy "${PROJNAME}" >/dev/null 2>&1 || true
   cd "${TESTDIR}"
+  run ddev config --project-name="${PROJNAME}" --project-tld=ddev.site
+  assert_success
+
+  export REDIS_MAJOR_VERSION=7
+  export HAS_DRUPAL_SETTINGS=false
+  export RUN_BGSAVE=false
+}
+
+health_checks() {
+  run ddev redis-cli INFO
+  assert_success
+  assert_output --partial "redis_version:$REDIS_MAJOR_VERSION."
+
+  if [ "${HAS_DRUPAL_SETTINGS}" = "true" ]; then
+    assert_file_exist web/sites/default/settings.ddev.redis.php
+
+    run grep -F "settings.ddev.redis.php" web/sites/default/settings.php
+    assert_success
+  else
+    assert_file_not_exist web/sites/default/settings.ddev.redis.php
+  fi
+
+  run ddev redis-cli "KEYS \*"
+  assert_success
+  assert_output ""
+
+  # populate 10000 keys
+  echo '' > keys.txt
+  run bash -c 'for i in {1..10000}; do echo "SET testkey-$i $i" >> keys.txt; done'
+  assert_success
+  run bash -c "cat keys.txt | ddev redis --pipe"
+  assert_success
+  assert_line --index 2 "errors: 0, replies: 10000"
+
+  if [ "${RUN_BGSAVE}" != "true" ]; then
+    return
+  fi
+
+  # Trigger a BGSAVE
+  run ddev redis BGSAVE
+  assert_success
+  assert_output "Background saving started"
+
+  sleep 10
+
+  run ddev stop
+  assert_success
+
+  run ddev start -y
+  assert_success
+
+  run ddev redis DBSIZE
+  assert_success
+  assert_output "10000"
+
+  run ddev redis-flush
+  assert_success
+  assert_output "OK"
+
+  run ddev redis DBSIZE
+  assert_success
+  assert_output "0"
 }
 
 teardown() {
-  cd ${TESTDIR}
-  ddev delete -Oy ${DDEV_SITENAME}
-  rm -rf ${TESTDIR}
+  set -eu -o pipefail
+  ddev delete -Oy ${PROJNAME} >/dev/null 2>&1
+  [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}
 }
 
-@test "basic installation" {
-  ddev config --project-name=${PROJNAME} --project-type=drupal --docroot=web
-  ddev start -y
-  cd ${TESTDIR}
-  ddev add-on get ${DIR}
-  ddev restart
-  ddev redis-cli INFO | grep "^redis_version:7."
-  # Check if Redis configuration was setup.
-  [ -f web/sites/default/settings.ddev.redis.php ]
-  grep -F 'settings.ddev.redis.php' web/sites/default/settings.php
+@test "install from directory" {
+  set -eu -o pipefail
+
+  export RUN_BGSAVE=true
+
+  run ddev start -y
+  assert_success
+
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  run ddev restart -y
+  assert_success
+  health_checks
 }
 
-@test "basic installation with Redis tag 6" {
-  ddev config --project-name=${PROJNAME} --project-type=drupal --docroot=web
-  ddev start -y
-  cd ${TESTDIR}
-  ddev add-on get ${DIR}
-  ddev dotenv set .ddev/.env.redis --redis-docker-image=redis:6
-  # Check if .env file for Redis exists.
-  [ -f .ddev/.env.redis ]
-  ddev restart
-  ddev redis-cli INFO | grep "^redis_version:6."
-  # Check if Redis configuration was setup.
-  [ -f web/sites/default/settings.ddev.redis.php ]
-  grep -F 'settings.ddev.redis.php' web/sites/default/settings.php
+# bats test_tags=release
+@test "install from release" {
+  set -eu -o pipefail
+  run ddev start -y
+  assert_success
+
+  echo "# ddev add-on get ${GITHUB_REPO} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${GITHUB_REPO}"
+  assert_success
+
+  run ddev restart -y
+  assert_success
+  health_checks
 }
 
-@test "non-Drupal installation" {
-  ddev config --project-name=${PROJNAME} --project-type=laravel --docroot=web
-  ddev start -y
-  cd ${TESTDIR}
-  ddev add-on get ${DIR}
-  ddev restart
-  ddev redis-cli INFO | grep "^redis_version:7."
-  # Drupal configuration should not be present
-  [ ! -f web/sites/default/settings.ddev.redis.php ]
+@test "Drupal installation" {
+  set -eu -o pipefail
+
+  export HAS_DRUPAL_SETTINGS=true
+
+  run ddev config --project-type=drupal --docroot=web
+  assert_success
+  run ddev start -y
+  assert_success
+
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  run ddev restart -y
+  assert_success
+  health_checks
+}
+
+@test "Laravel installation with redis:6" {
+  set -eu -o pipefail
+
+  export REDIS_MAJOR_VERSION=6
+
+  run ddev config --project-type=laravel --docroot=web
+  assert_success
+  run ddev start -y
+  assert_success
+
+  run ddev dotenv set .ddev/.env.redis --redis-docker-image=redis:${REDIS_MAJOR_VERSION}
+  assert_success
+  assert_file_exist .ddev/.env.redis
+
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  run ddev restart -y
+  assert_success
+  health_checks
 }
 
 @test "Drupal 7 installation" {
-  ddev config --project-name=${PROJNAME} --project-type=drupal7 --docroot=web
-  ddev start -y
-  cd ${TESTDIR}
-  ddev add-on get ${DIR}
-  ddev restart
-  ddev redis-cli INFO | grep "^redis_version:7."
-  # Drupal configuration should not be present
-  [ ! -f web/sites/default/settings.ddev.redis.php ]
+  set -eu -o pipefail
+
+  # Drupal configuration should not be present in Drupal 7
+  export HAS_DRUPAL_SETTINGS=false
+
+  run ddev config --project-type=drupal7 --docroot=web
+  assert_success
+  run ddev start -y
+  assert_success
+
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  run ddev restart -y
+  assert_success
+  health_checks
 }
 
-@test "Drupal 9 installation without settings management" {
-  ddev config --project-name=${PROJNAME} --disable-settings-management --project-type=drupal --docroot=web
-  ddev start -y
-  cd ${TESTDIR}
-  ddev add-on get ${DIR}
-  ddev restart
-  ddev redis-cli INFO | grep "^redis_version:7."
-  # Drupal configuration should not be present
-  [ ! -f web/sites/default/settings.ddev.redis.php ]
+@test "Drupal installation without settings management" {
+  set -eu -o pipefail
+
+  export HAS_DRUPAL_SETTINGS=false
+
+  run ddev config --disable-settings-management --project-type=drupal --docroot=web
+  assert_success
+  run ddev start -y
+  assert_success
+
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  run ddev restart -y
+  assert_success
+  health_checks
 }


### PR DESCRIPTION
## The Issue

Tests are outdated.

## How This PR Solves The Issue

- Uses bats libraries.
- Adds more health_checks from `ddev/ddev-redis-7`.
- Installs missing `ddev redis-flush` for #37

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-redis/tarball/20250425_stasadev_bats_tests
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
