### PR TITLE
fix: don't use ACLs by default, set `redis` password for optimized ACLs config, fixes #43

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,9 @@ Redis is available inside Docker containers with `redis:6379`.
 
 ## Redis Credentials
 
-| Field    | Value                 |
-|----------|-----------------------|
-| Username | `redis`               |
-| Password | `` (empty by default) |
+By default, no authentication is required.
+
+If you want to set up ACLs, refer to the [Redis documentation](https://redis.io/docs/latest/operate/oss_and_stack/management/security/acl/).
 
 ## Advanced Customization
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,14 @@ Redis is available inside Docker containers with `redis:6379`.
 
 By default, no authentication is required.
 
-If you want to set up ACLs, refer to the [Redis documentation](https://redis.io/docs/latest/operate/oss_and_stack/management/security/acl/).
+If you have the optimized config enabled (`ddev dotenv set .ddev/.env.redis --redis-optimized=true`), the credentials are:
+
+| Field    | Value   |
+|----------|---------|
+| Username | `redis` |
+| Password | `redis` |
+
+For more information about ACLs, see the [Redis documentation](https://redis.io/docs/latest/operate/oss_and_stack/management/security/acl/).
 
 ## Advanced Customization
 
@@ -48,6 +55,11 @@ To apply an optimized configuration from `ddev/ddev-redis-7`:
 ```bash
 ddev dotenv set .ddev/.env.redis --redis-optimized=true
 ddev add-on get ddev/ddev-redis
+
+# (optional) if you have an existing Redis volume, delete it to avoid problems with Redis:
+ddev stop
+docker volume rm ddev-$(ddev status -j | docker run -i --rm ddev/ddev-utilities jq -r '.raw.name')_redis
+
 ddev restart
 ```
 
@@ -58,6 +70,11 @@ To change the used Docker image:
 ```bash
 ddev dotenv set .ddev/.env.redis --redis-docker-image=redis:7
 ddev add-on get ddev/ddev-redis
+
+# (optional) if you have an existing Redis volume, delete it to avoid problems with Redis:
+ddev stop
+docker volume rm ddev-$(ddev status -j | docker run -i --rm ddev/ddev-utilities jq -r '.raw.name')_redis
+
 ddev restart
 ```
 

--- a/commands/redis/redis-cli
+++ b/commands/redis/redis-cli
@@ -6,4 +6,8 @@
 ## Example: "ddev redis-cli KEYS *" or "ddev redis-cli INFO" or "ddev redis-cli --version"
 ## Aliases: redis
 
-redis-cli -p 6379 -h redis $@
+if [ -f /etc/redis/conf/security.conf ]; then
+  redis-cli -p 6379 -h redis -a redis --no-auth-warning $@
+else
+  redis-cli -p 6379 -h redis $@
+fi

--- a/commands/redis/redis-cli
+++ b/commands/redis/redis-cli
@@ -6,5 +6,4 @@
 ## Example: "ddev redis-cli KEYS *" or "ddev redis-cli INFO" or "ddev redis-cli --version"
 ## Aliases: redis
 
-redis-cli -p 6379 -h redis -a "" --no-auth-warning "$@"
-
+redis-cli -p 6379 -h redis $@

--- a/commands/redis/redis-flush
+++ b/commands/redis/redis-flush
@@ -5,4 +5,8 @@
 ## Usage: redis-flush
 ## Example: "ddev redis-flush"
 
-redis-cli -p 6379 -h redis FLUSHALL ASYNC
+if [ -f /etc/redis/conf/security.conf ]; then
+  redis-cli -p 6379 -h redis -a redis --no-auth-warning FLUSHALL ASYNC
+else
+  redis-cli -p 6379 -h redis FLUSHALL ASYNC
+fi

--- a/commands/redis/redis-flush
+++ b/commands/redis/redis-flush
@@ -5,4 +5,4 @@
 ## Usage: redis-flush
 ## Example: "ddev redis-flush"
 
-redis-cli -a "" --no-auth-warning FLUSHALL ASYNC
+redis-cli -p 6379 -h redis FLUSHALL ASYNC

--- a/redis/redis.conf
+++ b/redis/redis.conf
@@ -12,7 +12,8 @@ maxmemory-policy allkeys-lfu
 #appendonly no
 #save ""
 
-# user config ending with "on >" means empty password
+# Redis 6+ supports ACL, if you need it:
+# user config ending with "on nopass" means no password
 # user config ending with "on >redis" means "redis" password
-user default ~* &* +@all on >
-user redis ~* &* +@all on >
+#user default ~* &* +@all on nopass
+#user redis ~* &* +@all on nopass

--- a/redis/redis.conf
+++ b/redis/redis.conf
@@ -11,9 +11,3 @@ maxmemory-policy allkeys-lfu
 # and uncomment the two lines below:
 #appendonly no
 #save ""
-
-# Redis 6+ supports ACL, if you need it:
-# user config ending with "on nopass" means no password
-# user config ending with "on >redis" means "redis" password
-#user default ~* &* +@all on nopass
-#user redis ~* &* +@all on nopass

--- a/redis/security.conf
+++ b/redis/security.conf
@@ -9,8 +9,6 @@
 # can be easily a long string from /dev/urandom or whatever, so by using a
 # long and unguessable password no brute force attack will be possible.
 
-# Redis 6+ supports ACL, if you need it:
-# user config ending with "on nopass" means no password
 # user config ending with "on >redis" means "redis" password
-#user default ~* &* +@all on nopass
-#user redis ~* &* +@all on nopass
+user default ~* &* +@all on >redis
+user redis ~* &* +@all on >redis

--- a/redis/security.conf
+++ b/redis/security.conf
@@ -9,7 +9,8 @@
 # can be easily a long string from /dev/urandom or whatever, so by using a
 # long and unguessable password no brute force attack will be possible.
 
-# user config ending with "on >" means empty password
+# Redis 6+ supports ACL, if you need it:
+# user config ending with "on nopass" means no password
 # user config ending with "on >redis" means "redis" password
-user default ~* &* +@all on >
-user redis ~* &* +@all on >
+#user default ~* &* +@all on nopass
+#user redis ~* &* +@all on nopass


### PR DESCRIPTION
## The Issue

- #43

## How This PR Solves The Issue

- Removes ACLs for default config.
- Sets `redis` in the same way as it was set for `ddev/ddev-redis-7` for optimized config.
- Adds instructions how to delete Redis volume.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-redis/tarball/20250428_stasadev_no_auth
ddev restart
ddev redis-cli INFO
ddev redis-cli KEYS \*
ddev redis-flush
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
