### PR TITLE
fix: remove old `redis` command from `ddev-redis-7`, fixes #46

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -29,6 +29,12 @@ post_install_actions:
   - |
     #ddev-description:Remove redis/scripts if there are no files
     rmdir redis/scripts 2>/dev/null || true
+  - |
+    #ddev-nodisplay
+    #ddev-description:Remove old `redis` command from `ddev-redis-7`
+    if grep "#ddev-generated" $DDEV_APPROOT/.ddev/commands/redis/redis 2>/dev/null; then
+      rm -f "$DDEV_APPROOT/.ddev/commands/redis/redis"
+    fi
 
 removal_actions:
   - |

--- a/install.yaml
+++ b/install.yaml
@@ -32,7 +32,7 @@ post_install_actions:
   - |
     #ddev-nodisplay
     #ddev-description:Remove old `redis` command from `ddev-redis-7`
-    if grep "#ddev-generated" $DDEV_APPROOT/.ddev/commands/redis/redis 2>/dev/null; then
+    if grep "#ddev-generated" $DDEV_APPROOT/.ddev/commands/redis/redis > /dev/null 2>&1; then
       rm -f "$DDEV_APPROOT/.ddev/commands/redis/redis"
     fi
 


### PR DESCRIPTION
## The Issue

- #46

## How This PR Solves The Issue

This PR attempts to remove the `redis` command if it is ownded by DDEV.

## Manual Testing Instructions

1. Create new project

```shell
ddev config
```

2. Add ddev-redis-7

```shell
ddev addon get ddev/ddev-redis-7
```

3. Restart DDEV

```shell
ddev restart
```

4. Migrate to ddev-redis

```shell
ddev dotenv set .ddev/.env.redis --redis-optimized=true
ddev add-on get https://github.com/ddev/ddev-redis/tarball/refs/pull/47/head
ddev restart
```

5. Run DDEV command and confirm `Command 'redis-cli' cannot have alias` does NOT appear.

```shell
$ ddev -v   
ddev version v1.24.4
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
